### PR TITLE
AMRSw-1249 stop sending quick stop

### DIFF
--- a/canopen_402/src/motor.cpp
+++ b/canopen_402/src/motor.cpp
@@ -111,7 +111,6 @@ Command402::TransitionTable::TransitionTable(){
     Op quickstop((1<<CW_Enable_Voltage), (1<<CW_Fault_Reset) | (1<<CW_Quick_Stop));
     /* 7*/ add(s::Ready_To_Switch_On, s::Quick_Stop_Active, quickstop); // transit to Switch_On_Disabled
     /*10*/ add(s::Switched_On, s::Quick_Stop_Active, quickstop); // transit to Switch_On_Disabled
-    /*11*/ add(s::Operation_Enable, s::Quick_Stop_Active, quickstop);
 
     // fault reset
     /*15*/ add(s::Fault, s::Switch_On_Disabled, Op((1<<CW_Fault_Reset), 0));


### PR DESCRIPTION
ref: [AMRSW-1249](https://lexxpluss.atlassian.net/browse/AMRSW-1249)

The motivation of this PR is not to activate quick stop.

[AMRSW-1249]: https://lexxpluss.atlassian.net/browse/AMRSW-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ