### PR TITLE
untangle/AMRSW-1929 Migrate wheel odometry node

### DIFF
--- a/can_msgs/msg/BUILD
+++ b/can_msgs/msg/BUILD
@@ -1,0 +1,3 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["Frame.msg"])

--- a/can_msgs/ros2/msg/BUILD
+++ b/can_msgs/ros2/msg/BUILD
@@ -1,0 +1,3 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["Frame.msg"])

--- a/can_msgs/ros2/msg/Frame.msg
+++ b/can_msgs/ros2/msg/Frame.msg
@@ -1,0 +1,7 @@
+std_msgs/Header header
+uint32 id
+bool is_rtr
+bool is_extended
+bool is_error
+uint8 dlc
+uint8[8] data


### PR DESCRIPTION
This PR adds Bazel BUILD files and a ROS2-compatible `Frame.msg` definition to the `can_msgs` package, required to support the wheel odometry node migration in LexxAuto (AMRSW-1929). 

Changes
  - `can_msgs/msg/BUILD`: Bazel BUILD file to export the existing ROS1 `Frame.msg`
  - `can_msgs/ros2/msg/Frame.msg`: ROS2-compatible `Frame.msg` definition (same fields as ROS1 version, using `std_msgs/Header`)
  - `can_msgs/ros2/msg/BUILD`: Bazel BUILD file to export the ROS2 `Frame.msg`
